### PR TITLE
fix: unexpected merge conflict

### DIFF
--- a/src/__snapshots__/create-curried-various-types.test.ts.snap
+++ b/src/__snapshots__/create-curried-various-types.test.ts.snap
@@ -144,6 +144,51 @@ type $_list_1<T> = T | undefined;
 "
 `;
 
+exports[`merge-non-conflicts should return correctly with mergable types 1`] = `
+"type $_00 = {
+    <T, U extends List<T>>(fn: (x: T) => T, container: U): $_list_11<T, U>;
+    <T, U extends Dictionary<T>>(fn: (x: T) => T, container: U): $_object_11<T, U>;
+    <T>(fn: (x: T) => T): $_10<T>;
+};
+type $_10<T> = {
+    <U extends List<T>>(container: U): $_list_11<T, U>;
+    <U extends Dictionary<T>>(container: U): $_object_11<T, U>;
+};
+type $_list_01<T, U extends List<T>> = {
+    (fn: (x: T) => T): $_list_11<T, U>;
+};
+type $_object_01<T, U extends Dictionary<T>> = {
+    (fn: (x: T) => T): $_object_11<T, U>;
+};
+type $_list_11<T, U extends List<T>> = U;
+type $_object_11<T, U extends Dictionary<T>> = U;
+"
+`;
+
+exports[`merge-non-conflicts should return correctly with un-mergable types 1`] = `
+"type $_00 = {
+    <T, U extends List<T>>(fn: (x: T) => T, container: U): $_list_11<T, U>;
+    <T>(fn: (x: T) => T): $_list_10<T>;
+    <X, Y extends Dictionary<X>>(fn: (x: X) => X, container: Y): $_object_11<X, Y>;
+    <X>(fn: (x: X) => X): $_object_10<X>;
+};
+type $_list_10<T> = {
+    <U extends List<T>>(container: U): $_list_11<T, U>;
+};
+type $_object_10<X> = {
+    <Y extends Dictionary<X>>(container: Y): $_object_11<X, Y>;
+};
+type $_list_01<T, U extends List<T>> = {
+    (fn: (x: T) => T): $_list_11<T, U>;
+};
+type $_object_01<X, Y extends Dictionary<X>> = {
+    (fn: (x: X) => X): $_object_11<X, Y>;
+};
+type $_list_11<T, U extends List<T>> = U;
+type $_object_11<X, Y extends Dictionary<X>> = Y;
+"
+`;
+
 exports[`non-generics should transform correctly with every option 1`] = `
 "type $_00 = {
     (a: number, b: number): $_number_11;

--- a/src/create-curried-various-types.test.ts
+++ b/src/create-curried-various-types.test.ts
@@ -29,6 +29,37 @@ it('should throw error if those function types have different length', () => {
   ).toThrowError();
 });
 
+describe('merge-non-conflicts', () => {
+  it('should return correctly with mergable types', () => {
+    expect(
+      dts.emit(
+        create_various_curried_types(
+          '$',
+          parse_types(`
+            function list<T, U extends List<T>>(fn: (x: T) => T, container: U): U;
+            function object<T, U extends Dictionary<T>>(fn: (x: T) => T, container: U): U;
+          `),
+        ),
+      ),
+    ).toMatchSnapshot();
+  });
+  it('should return correctly with un-mergable types', () => {
+    expect(
+      dts.emit(
+        create_various_curried_types(
+          '$',
+          parse_types(`
+            function list<T, U extends List<T>>(fn: (x: T) => T, container: U): U;
+            function object<X, Y extends Dictionary<X>>(fn: (x: X) => X, container: Y): Y;
+          `),
+        ),
+      ),
+    ).toMatchSnapshot();
+  });
+});
+
+it('should merge correctly with ');
+
 Object.keys(test_cases).forEach(case_name => {
   describe(case_name, () => {
     it('should transform correctly without any options', () => {

--- a/src/create-curried-various-types.ts
+++ b/src/create-curried-various-types.ts
@@ -10,6 +10,7 @@ import {
 } from './utils/constants';
 import { create_masks } from './utils/create-masks';
 import { create_selectable_signatures } from './utils/create-selectable-signatures';
+import { has_same_parameter } from './utils/has-same-parameter';
 
 /**
  * @hidden
@@ -54,16 +55,18 @@ export function create_various_curried_types(
 
   const masks = create_masks(parameters_length);
 
-  const types_parameters = keys.reduce<dts.IParameterDeclaration[][]>(
-    (reduced, key) => [...reduced, types[key].parameters!],
+  const function_types = keys.reduce<dts.IFunctionType[]>(
+    (reduced, key) => [...reduced, types[key]],
     [],
   );
 
   const non_conflicts = R.repeat(0, parameters_length).map((_, index) => {
-    const parameter = types_parameters[0][index];
-    return types_parameters
+    const main_function_type = function_types[0];
+    return function_types
       .slice(1)
-      .every(type_parameters => R.equals(type_parameters[index], parameter));
+      .every(current_function_type =>
+        has_same_parameter(main_function_type, current_function_type, index),
+      );
   });
 
   const conflict_declarations: dts.ITypeDeclaration[][] = [];

--- a/src/utils/has-same-parameter.ts
+++ b/src/utils/has-same-parameter.ts
@@ -1,0 +1,15 @@
+import * as dts from 'dts-element';
+import * as R from 'ramda';
+
+// tslint:disable-next-line:no-unused-variable no-duplicate-imports
+import { IFunctionType } from 'dts-element';
+
+export const has_same_parameter = (
+  function_type_1: dts.IFunctionType,
+  function_type_2: dts.IFunctionType,
+  parameter_index: number,
+) =>
+  R.equals(
+    function_type_1.parameters![parameter_index],
+    function_type_2.parameters![parameter_index],
+  );

--- a/src/utils/has-same-parameter.ts
+++ b/src/utils/has-same-parameter.ts
@@ -1,5 +1,7 @@
 import * as dts from 'dts-element';
 import * as R from 'ramda';
+import { get_generics_dependencies } from './get-generics-dependencies';
+import { has } from './has';
 
 // tslint:disable-next-line:no-unused-variable no-duplicate-imports
 import { IFunctionType } from 'dts-element';
@@ -8,8 +10,46 @@ export const has_same_parameter = (
   function_type_1: dts.IFunctionType,
   function_type_2: dts.IFunctionType,
   parameter_index: number,
-) =>
-  R.equals(
-    function_type_1.parameters![parameter_index],
-    function_type_2.parameters![parameter_index],
-  );
+) => {
+  const [first, second] = [
+    function_type_1,
+    function_type_2,
+  ].map(function_type => {
+    const { parameters = [], generics = [] } = function_type;
+    const parameter_type = parameters[parameter_index].type!;
+    return { generics, parameter_type };
+  });
+
+  if (!R.equals(first.parameter_type, second.parameter_type)) {
+    // suppose type that looks different should have different meaning
+    return false;
+  }
+
+  // check if the same generic name has the same meaning
+
+  const [generic_tree_1, generic_tree_2] = [first, second].map(data => {
+    const { generics, parameter_type } = data;
+    const parameter_generics_and_indexes = generics
+      .map((generic, index) => ({ generic, index }))
+      .filter(({ generic }) =>
+        has(parameter_type, {
+          kind: dts.ElementKind.GeneralType,
+          name: generic.name,
+        }),
+      );
+    const generics_dependencies = get_generics_dependencies(generics);
+    return parameter_generics_and_indexes.reduce<
+      Record<string, dts.IGenericDeclaration[]>
+    >(
+      (current, { generic, index }) => ({
+        ...current,
+        [generic.name]: generics_dependencies[index]
+          .slice()
+          .sort((a, b) => a.name.localeCompare(b.name)),
+      }),
+      {},
+    );
+  });
+
+  return R.equals(generic_tree_1, generic_tree_2);
+};


### PR DESCRIPTION
This PR adds additional check for the same generic name which might have different meaning.

(prototype)

```ts
function list<T, U extends List<T>>(fn: (x: T) => T, container: U): U;
function object<T, U extends Dictionary<T>>(fn: (x: T) => T, container: U): U;
```

(before/after)

```diff
type $_00 = {
    <T, U extends List<T>>(fn: (x: T) => T, container: U): $_list_11<T, U>;
    <T, U extends Dictionary<T>>(fn: (x: T) => T, container: U): $_object_11<T, U>;
    <T>(fn: (x: T) => T): $_10<T>;
};
type $_10<T> = {
    <U extends List<T>>(container: U): $_list_11<T, U>;
    <U extends Dictionary<T>>(container: U): $_object_11<T, U>;
};
-type $_01<T, U extends List<T>> = {
+type $_list_01<T, U extends List<T>> = {
    (fn: (x: T) => T): $_list_11<T, U>;
+};
+type $_object_01<T, U extends Dictionary<T>> = {
    (fn: (x: T) => T): $_object_11<T, U>;
};
type $_list_11<T, U extends List<T>> = U;
type $_object_11<T, U extends Dictionary<T>> = U;
```