### PR TITLE
feat: add `hoist_name` option

### DIFF
--- a/src/__snapshots__/create-curried-declarations.test.ts.snap
+++ b/src/__snapshots__/create-curried-declarations.test.ts.snap
@@ -197,8 +197,6 @@ type $_functor_11<U> = Functor<U>;
 exports[`should remove non-hoist kind in non-conflict types and remove hoist kind in selectable types with hoist_name = string  and type = Record<string, FunctionType> contains all_various 1`] = `
 "declare const $: $_0;
 type $_0 = {
-    (str: string): $_string_1;
-    <T>(list: List<T>): $_list_1<T>;
     <$SEL extends \\"1\\", $KIND extends \\"mixed\\">(): <T>(list: string | List<T>) => $_mixed_1<T>;
     <$SEL extends \\"1\\", $KIND extends \\"list\\">(): <T>(list: List<T>) => $_list_1<T>;
     <$SEL extends \\"1\\", $KIND extends \\"string\\">(): (str: string) => $_string_1;
@@ -214,11 +212,7 @@ exports[`should remove non-hoist kind in non-conflict types and remove hoist kin
 "declare const $: $_00;
 type $_00 = {
     <T, U>(fn: Morphism<T, U>): $_10<T, U>;
-    <T>(_fn: PH, list: List<T>): $_list_01<T>;
-    <T>(_fn: PH, functor: Functor<T>): $_functor_01<T>;
     <T>(_fn: PH, target: List<T> | Functor<T>): $_mixed_01<T>;
-    <T, U>(fn: Morphism<T, U>, list: List<T>): $_list_11<U>;
-    <T, U>(fn: Morphism<T, U>, functor: Functor<T>): $_functor_11<U>;
     <$SEL extends \\"11\\", $KIND extends \\"mixed\\">(): <T, U>(fn: Morphism<T, U>, target: List<T> | Functor<T>) => $_mixed_11<U>;
     <$SEL extends \\"11\\", $KIND extends \\"functor\\">(): <T, U>(fn: Morphism<T, U>, functor: Functor<T>) => $_functor_11<U>;
     <$SEL extends \\"11\\", $KIND extends \\"list\\">(): <T, U>(fn: Morphism<T, U>, list: List<T>) => $_list_11<U>;
@@ -229,8 +223,6 @@ type $_00 = {
     <T, U>(fn: Morphism<T, U>, target: List<T> | Functor<T>): $_mixed_11<U>;
 };
 type $_10<T, U> = {
-    (list: List<T>): $_list_11<U>;
-    (functor: Functor<T>): $_functor_11<U>;
     <$SEL extends \\"1\\", $KIND extends \\"mixed\\">(): (target: List<T> | Functor<T>) => $_mixed_11<U>;
     <$SEL extends \\"1\\", $KIND extends \\"functor\\">(): (functor: Functor<T>) => $_functor_11<U>;
     <$SEL extends \\"1\\", $KIND extends \\"list\\">(): (list: List<T>) => $_list_11<U>;

--- a/src/__snapshots__/create-curried-declarations.test.ts.snap
+++ b/src/__snapshots__/create-curried-declarations.test.ts.snap
@@ -194,6 +194,63 @@ type $_functor_11<U> = Functor<U>;
 "
 `;
 
+exports[`should remove non-hoist kind in non-conflict types and remove hoist kind in selectable types with hoist_name = string  and type = Record<string, FunctionType> contains all_various 1`] = `
+"declare const $: $_0;
+type $_0 = {
+    (str: string): $_string_1;
+    <T>(list: List<T>): $_list_1<T>;
+    <$SEL extends \\"1\\", $KIND extends \\"mixed\\">(): <T>(list: string | List<T>) => $_mixed_1<T>;
+    <$SEL extends \\"1\\", $KIND extends \\"list\\">(): <T>(list: List<T>) => $_list_1<T>;
+    <$SEL extends \\"1\\", $KIND extends \\"string\\">(): (str: string) => $_string_1;
+    <T>(list: string | List<T>): $_mixed_1<T>;
+};
+type $_string_1 = string;
+type $_list_1<T> = T[];
+type $_mixed_1<T> = string | T[];
+"
+`;
+
+exports[`should remove non-hoist kind in non-conflict types and remove hoist kind in selectable types with hoist_name = string  and type = Record<string, FunctionType> contains various_mixed 1`] = `
+"declare const $: $_00;
+type $_00 = {
+    <T, U>(fn: Morphism<T, U>): $_10<T, U>;
+    <T>(_fn: PH, list: List<T>): $_list_01<T>;
+    <T>(_fn: PH, functor: Functor<T>): $_functor_01<T>;
+    <T>(_fn: PH, target: List<T> | Functor<T>): $_mixed_01<T>;
+    <T, U>(fn: Morphism<T, U>, list: List<T>): $_list_11<U>;
+    <T, U>(fn: Morphism<T, U>, functor: Functor<T>): $_functor_11<U>;
+    <$SEL extends \\"11\\", $KIND extends \\"mixed\\">(): <T, U>(fn: Morphism<T, U>, target: List<T> | Functor<T>) => $_mixed_11<U>;
+    <$SEL extends \\"11\\", $KIND extends \\"functor\\">(): <T, U>(fn: Morphism<T, U>, functor: Functor<T>) => $_functor_11<U>;
+    <$SEL extends \\"11\\", $KIND extends \\"list\\">(): <T, U>(fn: Morphism<T, U>, list: List<T>) => $_list_11<U>;
+    <$SEL extends \\"01\\", $KIND extends \\"mixed\\">(): <T>(_fn: PH, target: List<T> | Functor<T>) => $_mixed_01<T>;
+    <$SEL extends \\"01\\", $KIND extends \\"functor\\">(): <T>(_fn: PH, functor: Functor<T>) => $_functor_01<T>;
+    <$SEL extends \\"01\\", $KIND extends \\"list\\">(): <T>(_fn: PH, list: List<T>) => $_list_01<T>;
+    <$SEL extends \\"1\\">(): <T, U>(fn: Morphism<T, U>) => $_10<T, U>;
+    <T, U>(fn: Morphism<T, U>, target: List<T> | Functor<T>): $_mixed_11<U>;
+};
+type $_10<T, U> = {
+    (list: List<T>): $_list_11<U>;
+    (functor: Functor<T>): $_functor_11<U>;
+    <$SEL extends \\"1\\", $KIND extends \\"mixed\\">(): (target: List<T> | Functor<T>) => $_mixed_11<U>;
+    <$SEL extends \\"1\\", $KIND extends \\"functor\\">(): (functor: Functor<T>) => $_functor_11<U>;
+    <$SEL extends \\"1\\", $KIND extends \\"list\\">(): (list: List<T>) => $_list_11<U>;
+    (target: List<T> | Functor<T>): $_mixed_11<U>;
+};
+type $_list_01<T> = {
+    <U>(fn: Morphism<T, U>): $_list_11<U>;
+};
+type $_functor_01<T> = {
+    <U>(fn: Morphism<T, U>): $_functor_11<U>;
+};
+type $_mixed_01<T> = {
+    <U>(fn: Morphism<T, U>): $_mixed_11<U>;
+};
+type $_list_11<U> = U[];
+type $_functor_11<U> = Functor<U>;
+type $_mixed_11<U> = U[] | Functor<U>;
+"
+`;
+
 exports[`should transform correctly with type = FunctionType 1`] = `
 "declare const $: $_000;
 type $_000 = {

--- a/src/create-curried-declarations.test.ts
+++ b/src/create-curried-declarations.test.ts
@@ -11,6 +11,11 @@ const test_cases = {
     function list<T, U>(fn: Morphism<T, U>, list: List<T>): U[];
     function functor<T, U>(fn: Morphism<T, U>, functor: Functor<T>): Functor<U>;
   `,
+  various_mixed: `
+    function list<T, U>(fn: Morphism<T, U>, list: List<T>): U[];
+    function functor<T, U>(fn: Morphism<T, U>, functor: Functor<T>): Functor<U>;
+    function mixed<T, U>(fn: Morphism<T, U>, target: List<T> | Functor<T>): U[] | Functor<U>;
+  `,
   all_various: `
     function string(str: string): string;
     function list<T>(list: List<T>): T[];
@@ -75,6 +80,22 @@ it('should inline return type correctly with inline_return_type = true and type 
   expect(
     emit_curried_declarations(test_cases.all_various, {
       inline_return_type: true,
+    }),
+  ).toMatchSnapshot();
+});
+
+it('should remove non-hoist kind in non-conflict types and remove hoist kind in selectable types with hoist_name = string  and type = Record<string, FunctionType> contains various_mixed', () => {
+  expect(
+    emit_curried_declarations(test_cases.various_mixed, {
+      hoist_name: 'mixed',
+    }),
+  ).toMatchSnapshot();
+});
+
+it('should remove non-hoist kind in non-conflict types and remove hoist kind in selectable types with hoist_name = string  and type = Record<string, FunctionType> contains all_various', () => {
+  expect(
+    emit_curried_declarations(test_cases.all_various, {
+      hoist_name: 'mixed',
     }),
   ).toMatchSnapshot();
 });

--- a/src/create-curried-types.ts
+++ b/src/create-curried-types.ts
@@ -25,6 +25,7 @@ export interface CreateCurriedDeclarationsOptions
   get_function_type_name?: (name: string, mask: string) => string;
   get_function_parameter_placeholder_name?: (name: string) => string;
   inline_return_type?: boolean;
+  hoist_name?: string;
 }
 
 /**

--- a/src/create-curried-various-types.ts
+++ b/src/create-curried-various-types.ts
@@ -26,6 +26,7 @@ export function create_various_curried_types(
     get_placeholder_type = get_placeholder_type_default,
     get_selectable_kind_name,
     get_selectable_selector_name,
+    hoist_name,
   } = options;
 
   const is_placeholder = (value: dts.IType) =>
@@ -53,6 +54,18 @@ export function create_various_curried_types(
     ],
     [],
   );
+
+  const hoist_types_index =
+    hoist_name === undefined ? -1 : keys.indexOf(hoist_name);
+  const hoist_type_members =
+    hoist_types_index !== -1 &&
+    curried_types_declarations[hoist_types_index].reduce(
+      (a, b) => [
+        ...a,
+        ...((b.type as dts.IObjectType).members as dts.IObjectMember[]),
+      ],
+      [] as dts.IObjectMember[],
+    );
 
   const masks = create_masks(parameters_length);
 
@@ -174,7 +187,11 @@ export function create_various_curried_types(
           ] = function_type;
         } else {
           members.push(
-            member,
+            ...(index >= non_conflict_declarations.length ||
+            !hoist_type_members ||
+            hoist_type_members.indexOf(member) !== -1
+              ? [member]
+              : []),
             ...(selectable && origin_members.length > 1
               ? [mixed_type_declarations_selectables[index][member_index]]
               : []),


### PR DESCRIPTION
With this option (`hoist_name: "mixed"` for example), non-hoist normal members will be removed:

```diff
 declare const $: $_0;
 type $_0 = {
-    (str: string): $_string_1;
-    <T>(list: List<T>): $_list_1<T>;
     <$SEL extends "1", $KIND extends "mixed">(): <T>(list: string | List<T>) => $_mixed_1<T>;
     <$SEL extends "1", $KIND extends "list">(): <T>(list: List<T>) => $_list_1<T>;
     <$SEL extends "1", $KIND extends "string">(): (str: string) => $_string_1;
     <T>(list: string | List<T>): $_mixed_1<T>;
 };
 type $_string_1 = string;
 type $_list_1<T> = T[];
 type $_mixed_1<T> = string | T[];
```

```diff
 declare const $: $_00;
 type $_00 = {
     <T, U>(fn: Morphism<T, U>): $_10<T, U>;
-    <T>(_fn: PH, list: List<T>): $_list_01<T>;
-    <T>(_fn: PH, functor: Functor<T>): $_functor_01<T>;
     <T>(_fn: PH, target: List<T> | Functor<T>): $_mixed_01<T>;
-    <T, U>(fn: Morphism<T, U>, list: List<T>): $_list_11<U>;
-    <T, U>(fn: Morphism<T, U>, functor: Functor<T>): $_functor_11<U>;
     <$SEL extends "11", $KIND extends "mixed">(): <T, U>(fn: Morphism<T, U>, target: List<T> | Functor<T>) => $_mixed_11<U>;
     <$SEL extends "11", $KIND extends "functor">(): <T, U>(fn: Morphism<T, U>, functor: Functor<T>) => $_functor_11<U>;
     <$SEL extends "11", $KIND extends "list">(): <T, U>(fn: Morphism<T, U>, list: List<T>) => $_list_11<U>;
     <$SEL extends "01", $KIND extends "mixed">(): <T>(_fn: PH, target: List<T> | Functor<T>) => $_mixed_01<T>;
     <$SEL extends "01", $KIND extends "functor">(): <T>(_fn: PH, functor: Functor<T>) => $_functor_01<T>;
     <$SEL extends "01", $KIND extends "list">(): <T>(_fn: PH, list: List<T>) => $_list_01<T>;
     <$SEL extends "1">(): <T, U>(fn: Morphism<T, U>) => $_10<T, U>;
     <T, U>(fn: Morphism<T, U>, target: List<T> | Functor<T>): $_mixed_11<U>;
 };
 type $_10<T, U> = {
-    (list: List<T>): $_list_11<U>;
-    (functor: Functor<T>): $_functor_11<U>;
     <$SEL extends "1", $KIND extends "mixed">(): (target: List<T> | Functor<T>) => $_mixed_11<U>;
     <$SEL extends "1", $KIND extends "functor">(): (functor: Functor<T>) => $_functor_11<U>;
     <$SEL extends "1", $KIND extends "list">(): (list: List<T>) => $_list_11<U>;
     (target: List<T> | Functor<T>): $_mixed_11<U>;
 };
 type $_list_01<T> = {
     <U>(fn: Morphism<T, U>): $_list_11<U>;
 };
 type $_functor_01<T> = {
     <U>(fn: Morphism<T, U>): $_functor_11<U>;
 };
 type $_mixed_01<T> = {
     <U>(fn: Morphism<T, U>): $_mixed_11<U>;
 };
 type $_list_11<U> = U[];
 type $_functor_11<U> = Functor<U>;
 type $_mixed_11<U> = U[] | Functor<U>;
```